### PR TITLE
Fix header include case and remove duplicate include

### DIFF
--- a/Plugins/GameFeatures/BreakawayCore/Source/BreakawayCoreRuntime/Private/BwayCharacterMovementComponent.cpp
+++ b/Plugins/GameFeatures/BreakawayCore/Source/BreakawayCoreRuntime/Private/BwayCharacterMovementComponent.cpp
@@ -1,8 +1,6 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 // Source: LyraCharacterMovementComponent_Slide.cpp
 #include "BwayCharacterMovementComponent.h"
-
-#include "BwayCharacterMovementComponent.h"
 #include "GameFramework/Character.h"
 #include "Components/CapsuleComponent.h"
 #include "AbilitySystemComponent.h"

--- a/Plugins/GameFeatures/BreakawayCore/Source/BreakawayCoreRuntime/Public/BwayCharacterMovementComponent.h
+++ b/Plugins/GameFeatures/BreakawayCore/Source/BreakawayCoreRuntime/Public/BwayCharacterMovementComponent.h
@@ -6,7 +6,7 @@
 #include "BwayCharacterWithAbilities.h"
 #include "Character/LyraCharacterMovementComponent.h"
 #include "InputAction.h" // Add this include
-#include "Gameplaytagcontainer.h"
+#include "GameplayTagContainer.h"
 #include "BwayCharacterMovementComponent.generated.h"
 
 class UAbilitySystemComponent;


### PR DESCRIPTION
## Summary
- fix case-sensitive include path in BwayCharacterMovementComponent.h
- remove duplicate include line in BwayCharacterMovementComponent.cpp

## Testing
- `echo "no tests" && true`

------
https://chatgpt.com/codex/tasks/task_e_684099cc89a0832d85d22542b24dd829